### PR TITLE
chore: support global.priorityClassName

### DIFF
--- a/charts/steadybit-extension-grafana/Chart.yaml
+++ b/charts/steadybit-extension-grafana/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: steadybit-extension-grafana
 description: Steadybit grafana extension Helm chart for Kubernetes.
-version: 1.2.14
+version: 1.2.15
 appVersion: v1.0.11
 home: https://www.steadybit.com/
 icon: https://steadybit-website-assets.s3.amazonaws.com/logo-symbol-transparent.png

--- a/charts/steadybit-extension-grafana/templates/deployment.yaml
+++ b/charts/steadybit-extension-grafana/templates/deployment.yaml
@@ -36,7 +36,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
-      {{- with .Values.priorityClassName }}
+      {{- with (.Values.priorityClassName | default (dig "priorityClassName" nil (.Values.global | default dict))) }}
       priorityClassName: {{ . }}
       {{- end }}
       {{- with .Values.podSecurityContext }}


### PR DESCRIPTION
Support falling back to global.priorityClassName when extension-specific priorityClassName is not set.