### PR TITLE
feat: support if-none-match for the extension list endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## (next)
+
+- Support if-none-match for the extension list endpoint
+
 ## v1.0.12
 
 - feat(chart): split image.name into image.registry + image.name

--- a/main.go
+++ b/main.go
@@ -5,6 +5,8 @@
 package main
 
 import (
+	"time"
+
 	_ "github.com/KimMachineGun/automemlimit" // By default, it sets `GOMEMLIMIT` to 90% of cgroup's memory limit.
 	"github.com/go-resty/resty/v2"
 	"github.com/rs/zerolog"
@@ -22,8 +24,9 @@ import (
 	"github.com/steadybit/extension-kit/extlogging"
 	"github.com/steadybit/extension-kit/extruntime"
 	"github.com/steadybit/extension-kit/extsignals"
-	"time"
 )
+
+var startedAt = time.Now().Format(time.RFC3339)
 
 func main() {
 	extlogging.InitZeroLog()
@@ -38,11 +41,11 @@ func main() {
 	config.ValidateConfiguration()
 	initRestyClient()
 
-	exthttp.RegisterHttpHandler("/", exthttp.GetterAsHandler(getExtensionList))
-
 	discovery_kit_sdk.Register(extalertrules.NewAlertDiscovery())
 	action_kit_sdk.RegisterAction(extalertrules.NewAlertRuleStateCheckAction())
 	extannotations.RegisterEventListenerHandlers()
+
+	exthttp.RegisterHttpHandler("/", exthttp.IfNoneMatchHandler(func() string { return startedAt }, exthttp.GetterAsHandler(getExtensionList)))
 
 	extsignals.ActivateSignalHandlers()
 


### PR DESCRIPTION
## Summary
- Wrap the `"/"` index handler with `exthttp.IfNoneMatchHandler` using a startup timestamp as ETag
- Allows clients to skip re-fetching the unchanged extension list via `If-None-Match` header
- Move index handler registration to after all action/discovery registrations for consistency

## Test plan
- [ ] Verify extension starts and responds to `GET /` with an `ETag` header
- [ ] Verify `GET /` with matching `If-None-Match` header returns `304 Not Modified`

🤖 Generated with [Claude Code](https://claude.com/claude-code)