### PR TITLE
docs: remove stray build: bullet from latest CHANGELOG entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## v1.1.4
 
-- build: rename workflow_dispatch input labels for the GH UI
 - chore(deps): bump alpine from 3.23 to 3.24
 - chore(deps): bump golang.org/x/net to v0.55.0 (CVE-2026-39821) (#88)
 - chore(deps): update dependencies


### PR DESCRIPTION
The auto-patch-release workflow added `- build: rename workflow_dispatch input labels for the GH UI` to the latest CHANGELOG entry. That bullet is a CI label rename with no runtime impact and shouldn't be user-facing.

A companion extension-kit PR adds `^build: ` to the default ignore regex so future runs skip such commits.