### PR TITLE
feat(alert rule check): add fail early option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Add a "Fail early" option to the alert rule check. When enabled (the default, matching the previous behavior), the check fails as soon as a deviating state is observed. When disabled, the check keeps collecting events for the whole duration and only fails at the end of the step.
+
 ## v1.1.4
 
 - chore(deps): bump alpine from 3.23 to 3.24

--- a/extalertrules/check.go
+++ b/extalertrules/check.go
@@ -229,20 +229,23 @@ func AlertRuleCheckStatus(ctx context.Context, state *AlertRuleCheckState, clien
 	if len(state.ExpectedState) > 0 {
 		if state.StateCheckMode == stateCheckModeAllTheTime {
 			if !slices.Contains(state.ExpectedState, alertRule.State) {
-				title := fmt.Sprintf("AlertRule '%s' has state '%s' whereas '%s' is expected.",
-					alertRule.Name,
-					alertRule.State,
-					state.ExpectedState)
 				if state.FailEarly {
-					// Fail as soon as a deviating state is observed.
+					// Fail as soon as a deviating state is observed (present tense - it is deviating now).
 					checkError = new(action_kit_api.ActionKitError{
-						Title:  title,
+						Title: fmt.Sprintf("AlertRule '%s' has state '%s' whereas '%s' is expected.",
+							alertRule.Name,
+							alertRule.State,
+							state.ExpectedState),
 						Status: extutil.Ptr(action_kit_api.Failed),
 					})
 				} else {
-					// Keep collecting events and remember the deviation to report it at the end of the step.
+					// Keep collecting events and remember the deviation to report it at the end of the
+					// step (past tense - the state may have recovered by the time this is reported).
 					state.DeviationSeen = true
-					state.DeviationTitle = title
+					state.DeviationTitle = fmt.Sprintf("AlertRule '%s' had state '%s' whereas '%s' is expected.",
+						alertRule.Name,
+						alertRule.State,
+						state.ExpectedState)
 				}
 			}
 			if !state.FailEarly && completed && state.DeviationSeen {

--- a/extalertrules/check.go
+++ b/extalertrules/check.go
@@ -39,6 +39,11 @@ type AlertRuleCheckState struct {
 	ExpectedState       []string
 	StateCheckMode      string
 	StateCheckSuccess   bool
+	FailEarly           bool
+	// DeviationSeen and DeviationTitle are used in 'fail at end' mode (FailEarly = false) to remember
+	// that a deviating state was observed during the step so the failure can be reported once the step ends.
+	DeviationSeen  bool
+	DeviationTitle string
 }
 
 func NewAlertRuleStateCheckAction() action_kit_sdk.Action[AlertRuleCheckState] {
@@ -126,6 +131,16 @@ func (m *AlertRuleStateCheckAction) Describe() action_kit_api.ActionDescription 
 				Required: new(true),
 				Order:    new(3),
 			},
+			{
+				Name:         "failEarly",
+				Label:        "Fail early",
+				Description:  new("If enabled, the check fails as soon as a deviating state is observed. If disabled, the check keeps collecting events for the whole duration and only fails at the end of the step. Only affects the 'All the time' mode; 'At least once' can only be evaluated at the end of the step."),
+				Type:         action_kit_api.ActionParameterTypeBoolean,
+				DefaultValue: new("true"),
+				Advanced:     new(true),
+				Required:     new(false),
+				Order:        new(4),
+			},
 		},
 		Widgets: new([]action_kit_api.Widget{
 			action_kit_api.StateOverTimeWidget{
@@ -176,6 +191,12 @@ func (m *AlertRuleStateCheckAction) Prepare(_ context.Context, state *AlertRuleC
 		stateCheckMode = fmt.Sprintf("%v", request.Config["stateCheckMode"])
 	}
 
+	// Default to failing early to preserve the previous behavior for experiments that don't set this parameter.
+	state.FailEarly = true
+	if request.Config["failEarly"] != nil {
+		state.FailEarly = extutil.ToBool(request.Config["failEarly"])
+	}
+
 	state.AlertRuleId = alertRuleId[0]
 	state.AlertRuleDatasource = request.Target.Attributes["grafana.alert-rule.datasource"][0]
 	state.AlertRuleName = request.Target.Attributes["grafana.alert-rule.name"][0]
@@ -208,11 +229,25 @@ func AlertRuleCheckStatus(ctx context.Context, state *AlertRuleCheckState, clien
 	if len(state.ExpectedState) > 0 {
 		if state.StateCheckMode == stateCheckModeAllTheTime {
 			if !slices.Contains(state.ExpectedState, alertRule.State) {
+				title := fmt.Sprintf("AlertRule '%s' has state '%s' whereas '%s' is expected.",
+					alertRule.Name,
+					alertRule.State,
+					state.ExpectedState)
+				if state.FailEarly {
+					// Fail as soon as a deviating state is observed.
+					checkError = new(action_kit_api.ActionKitError{
+						Title:  title,
+						Status: extutil.Ptr(action_kit_api.Failed),
+					})
+				} else {
+					// Keep collecting events and remember the deviation to report it at the end of the step.
+					state.DeviationSeen = true
+					state.DeviationTitle = title
+				}
+			}
+			if !state.FailEarly && completed && state.DeviationSeen {
 				checkError = new(action_kit_api.ActionKitError{
-					Title: fmt.Sprintf("AlertRule '%s' has state '%s' whereas '%s' is expected.",
-						alertRule.Name,
-						alertRule.State,
-						state.ExpectedState),
+					Title:  state.DeviationTitle,
 					Status: extutil.Ptr(action_kit_api.Failed),
 				})
 			}

--- a/extalertrules/check_test.go
+++ b/extalertrules/check_test.go
@@ -166,6 +166,7 @@ func TestAlertRuleCheckStatus_AllTheTimeMode_Mismatch(t *testing.T) {
 		AlertRuleId:         "id2",
 		ExpectedState:       []string{"normal"},
 		StateCheckMode:      stateCheckModeAllTheTime,
+		FailEarly:           true,
 		End:                 time.Now().Add(-1 * time.Second), // already completed
 	}
 
@@ -232,7 +233,7 @@ func TestAlertRuleCheckStatus_AllTheTime_FailAtEnd(t *testing.T) {
 	assert.NoError(t, err)
 	assert.True(t, res.Completed)
 	assert.NotNil(t, res.Error)
-	assert.Contains(t, res.Error.Title, "has state 'firing' whereas")
+	assert.Contains(t, res.Error.Title, "had state 'firing' whereas") // past tense at end of step
 }
 
 func TestAlertRuleCheckStatus_AllTheTime_FailAtEnd_NoDeviation(t *testing.T) {

--- a/extalertrules/check_test.go
+++ b/extalertrules/check_test.go
@@ -50,7 +50,7 @@ func TestPrepareExtractsState(t *testing.T) {
 	//require.Equal(t, "prometheus", state.AlertRuleDatasource)
 	require.Equal(t, "test_firing", state.AlertRuleName)
 	require.Equal(t, "firing", state.ExpectedState[0])
-
+	require.True(t, state.FailEarly) // defaults to true when not provided (non-breaking for old experiments)
 }
 
 // RoundTripperFunc lets us stub HTTP responses.
@@ -175,6 +175,90 @@ func TestAlertRuleCheckStatus_AllTheTimeMode_Mismatch(t *testing.T) {
 	assert.True(t, res.Completed)
 	assert.NotNil(t, res.Error)
 	assert.Contains(t, res.Error.Title, "has state 'firing' whereas")
+}
+
+func newFiringClient() *resty.Client {
+	body := `{"data":{"groups":[{"rules":[{"name":"r","state":"firing"}]}]}}`
+	return newTestClient(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: 200,
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+		}, nil
+	})
+}
+
+func TestAlertRuleCheckStatus_AllTheTime_FailEarly(t *testing.T) {
+	client := newFiringClient()
+	state := &AlertRuleCheckState{
+		AlertRuleDatasource: "DS1",
+		AlertRuleName:       "r",
+		AlertRuleId:         "id",
+		ExpectedState:       []string{"normal"},
+		StateCheckMode:      stateCheckModeAllTheTime,
+		FailEarly:           true,
+		End:                 time.Now().Add(1 * time.Minute), // not yet completed
+	}
+
+	res, err := AlertRuleCheckStatus(context.Background(), state, client)
+	assert.NoError(t, err)
+	assert.False(t, res.Completed)
+	assert.NotNil(t, res.Error, "fail early should report the deviation immediately")
+	assert.Contains(t, res.Error.Title, "has state 'firing' whereas")
+}
+
+func TestAlertRuleCheckStatus_AllTheTime_FailAtEnd(t *testing.T) {
+	client := newFiringClient()
+	state := &AlertRuleCheckState{
+		AlertRuleDatasource: "DS1",
+		AlertRuleName:       "r",
+		AlertRuleId:         "id",
+		ExpectedState:       []string{"normal"},
+		StateCheckMode:      stateCheckModeAllTheTime,
+		FailEarly:           false,
+		End:                 time.Now().Add(1 * time.Minute), // not yet completed
+	}
+
+	// First poll: deviation observed but time not up -> no error, deviation remembered
+	res, err := AlertRuleCheckStatus(context.Background(), state, client)
+	assert.NoError(t, err)
+	assert.False(t, res.Completed)
+	assert.Nil(t, res.Error, "should not fail early")
+	assert.True(t, state.DeviationSeen)
+
+	// Second poll: time is up -> fails at the end
+	state.End = time.Now().Add(-1 * time.Second)
+	res, err = AlertRuleCheckStatus(context.Background(), state, client)
+	assert.NoError(t, err)
+	assert.True(t, res.Completed)
+	assert.NotNil(t, res.Error)
+	assert.Contains(t, res.Error.Title, "has state 'firing' whereas")
+}
+
+func TestAlertRuleCheckStatus_AllTheTime_FailAtEnd_NoDeviation(t *testing.T) {
+	body := `{"data":{"groups":[{"rules":[{"name":"r","state":"normal"}]}]}}`
+	client := newTestClient(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: 200,
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+		}, nil
+	})
+	state := &AlertRuleCheckState{
+		AlertRuleDatasource: "DS1",
+		AlertRuleName:       "r",
+		AlertRuleId:         "id",
+		ExpectedState:       []string{"normal"},
+		StateCheckMode:      stateCheckModeAllTheTime,
+		FailEarly:           false,
+		End:                 time.Now().Add(-1 * time.Second), // already completed
+	}
+
+	res, err := AlertRuleCheckStatus(context.Background(), state, client)
+	assert.NoError(t, err)
+	assert.True(t, res.Completed)
+	assert.Nil(t, res.Error)
+	assert.False(t, state.DeviationSeen)
 }
 
 func TestAlertRuleCheckStatus_AtLeastOnceMode(t *testing.T) {


### PR DESCRIPTION
## Problem

The ending time of our checks isn't consistently applied, which makes experiments hard to time. A check can fail early (on the first deviating event) or only at the end of the step, with no way to choose. This adds a per-check option, following the reference implementation in `extension-datadog` (and matching `extension-dynatrace`).

## Change

Adds a **`failEarly` boolean** to the Grafana alert rule check:

- **Enabled (default)** — the check fails as soon as a deviating state is observed (today's `All the time` behavior).
- **Disabled** — the check keeps collecting events for the whole step duration and only fails at the end.

Details:
- Parameter lives in the **Advanced** section, is **optional**, and defaults to `true` both in its description and in `Prepare` (when the key is absent), so **existing experiments are non-breaking**.
- Fail-at-end is implemented by remembering the deviation in state (`DeviationSeen`/`DeviationTitle`) and only emitting the error once the step completes.
- Only affects `All the time` mode. `At least once` can only be evaluated at the end of the step, so the option is a no-op there (documented in the parameter description).

The parameter description is what the Hub renders, satisfying the "documented in the Hub" acceptance criterion.

## Note

The check reads a single determinate `alertRule.State`, and a missing rule returns a hard error, so the "unknown/no-data silently passes" bug fixed in datadog#216 does **not** apply here.

## Tests

- Added `FailEarly` extraction assertion plus `AllTheTime_FailEarly`, `AllTheTime_FailAtEnd` (deviation then end), and `AllTheTime_FailAtEnd_NoDeviation`.
- 11/11 tests pass, `go vet` clean.